### PR TITLE
Implement pay developers functionality

### DIFF
--- a/ScrumAge/BlazorUI/Pages/Board.razor
+++ b/ScrumAge/BlazorUI/Pages/Board.razor
@@ -4,6 +4,7 @@
 @using static GameLibrary.Services.GameController
 @using GameLibrary.Interfaces
 @using GameLibrary.Models
+@using GameLibrary.Services
 @using GameboardComponents
 
 
@@ -130,6 +131,56 @@ else {
         if (Game.Round == GameRound.TALLY_SCORE) {
             Game.Round = GameRound.PLACE_FIGURES;
         }
+    }
+
+    private async Task PlaceDevelopersOnLocation(ILocation location) {
+        int numDevelopersPlaced = 0;
+        bool notInput = true;
+        while (notInput) {
+            try {
+                var temp = await JSRuntime.InvokeAsync<string>("prompt", "How many players would you like to place? ");
+                numDevelopersPlaced = Int32.Parse(temp);
+                notInput = false;
+            }
+            catch (Exception) {
+                // Player hit cancel or didn't input an integer
+            }
+        }
+
+        PlaceDevelopers(numDevelopersPlaced, location);
+        message = GameLog.GetInstance().CurrentMessage;
+
+        this.StateHasChanged();
+    }
+
+    private void TakeActionOnLocation(ILocation location)
+    {
+        TakeLocationAction(location);
+        message = GameLog.GetInstance().CurrentMessage;
+        if (Game.Round == GameRound.PAY_DEVELOPERS)
+        {
+            PayDevelopers();
+        }
+    }
+
+    private void PayDevelopers()
+    {
+        Dictionary<int, int> playerNumberToNumDevelopersLeft = PayDevelopersHandler.PayDevelopers();
+        foreach (int playerNumber in playerNumberToNumDevelopersLeft.Keys)
+        {
+            Dictionary<Resources, int> resourcesPaid = PromptForResourcesInput();
+
+            //TODO: Ensure correct amount of resources, and subtract from player
+        }
+    }
+
+    private Dictionary<Resources, int> PromptForResourcesInput()
+    {
+        Dictionary<Resources, int> numResources = new Dictionary<Resources, int>();
+
+        //TODO: Get number for each resource through jQuery Dialog
+
+        return numResources;
     }
 
     protected async Task ButtonClickedChanged() {

--- a/ScrumAge/BlazorUI/Pages/Board.razor
+++ b/ScrumAge/BlazorUI/Pages/Board.razor
@@ -11,11 +11,23 @@
 
 <h1>@message</h1>
 
-@if (ButtonClicked == true && Game.Round == GameRound.PLACE_FIGURES) {
-    <PlaceDeveloperDialogBox Location="ClickedLocation" OnPlaceDeveloper="ButtonClickedChanged" />
+@if (ShowDialog) {
+    @switch(Game.Round) {
+        case GameRound.PLACE_FIGURES:
+            <PlaceDeveloperDialogBox Location="ClickedLocation" OnPlaceDeveloper="ShowDialogChanged" />
+            break;
+        case GameRound.TAKE_ACTIONS:
+            <TakeActionDialogBox Location="ClickedLocation" OnPlaceDeveloper="ShowDialogChanged" />
+            break;
+        case GameRound.PAY_DEVELOPERS:
+            <ResourceSelectorDialogBox OnConfirm="ShowDialogChanged" />
+            break;
+        default:
+            break;
+    }
 }
-else if (ButtonClicked == true && Game.Round == GameRound.TAKE_ACTIONS) {
-    <TakeActionDialogBox Location="ClickedLocation" OnPlaceDeveloper="ButtonClickedChanged" />
+else if (Game.Round == GameRound.PAY_DEVELOPERS) {
+    CheckPayDevelopers();
 }
 else {
     <table>
@@ -93,7 +105,7 @@ else {
         <tr>
             <th class="padColOne">
                 <h3 style="display: block">Game Round: @Game.Round</h3>
-                <ResourceBoardComponent _Player="Game.PlayersInRound.Peek()" />
+                <ResourceBoardComponent _Player="Game.CurrentPlayer" />
             </th>
         </tr>
 
@@ -110,21 +122,27 @@ else {
     public string playerNames { get; set; }
 
     public Gameboard Game { get; set; }
+    public GameLog Log { get; set; }
 
-    public bool ButtonClicked { get; set; }
+    public bool ShowDialog { get; set; }
 
     public ILocation ClickedLocation { get; set; }
+
+    public Dictionary<int, int> PlayerNumberToNumDevelopersLeft { get; set; }
+    public static Dictionary<Resources, int> NumResources { get; set; }
 
     private string message = "";
 
     protected override void OnInitialized() {
         Game = InitializeGameboard(playerNames);
-        message = GameLog.GetInstance().CurrentMessage;
-        ButtonClicked = false;
+        Log = GameLog.GetInstance();
+        UpdateMessage();
+        ShowDialog = false;
+        NumResources = null;
     }
 
     private async Task LocationClick(MouseEventArgs e, ILocation location) {
-        ButtonClicked = true;
+        ShowDialog = true;
         ClickedLocation = location;
         this.StateHasChanged();
 
@@ -148,44 +166,56 @@ else {
         }
 
         PlaceDevelopers(numDevelopersPlaced, location);
-        message = GameLog.GetInstance().CurrentMessage;
+        UpdateMessage();
 
         this.StateHasChanged();
     }
 
-    private void TakeActionOnLocation(ILocation location)
-    {
+    private void TakeActionOnLocation(ILocation location) {
         TakeLocationAction(location);
-        message = GameLog.GetInstance().CurrentMessage;
-        if (Game.Round == GameRound.PAY_DEVELOPERS)
-        {
-            PayDevelopers();
+        UpdateMessage();
+    }
+
+    private void StartPayDevelopers() {
+        PlayerNumberToNumDevelopersLeft = PayDevelopersHandler.AutoPayDevelopers();
+        if (PlayerNumberToNumDevelopersLeft.Count > 0) {
+            Log.AddMessage($"{Game.CurrentPlayer.Name} must pay {PlayerNumberToNumDevelopersLeft[Game.CurrentPlayer.Number]} developers with resources.");
+            ShowDialog = true;
         }
-    }
-
-    private void PayDevelopers()
-    {
-        Dictionary<int, int> playerNumberToNumDevelopersLeft = PayDevelopersHandler.PayDevelopers();
-        foreach (int playerNumber in playerNumberToNumDevelopersLeft.Keys)
-        {
-            Dictionary<Resources, int> resourcesPaid = PromptForResourcesInput();
-
-            //TODO: Ensure correct amount of resources, and subtract from player
+        else {
+            GameController.StartNewRound();
         }
+
+        UpdateMessage();
+        this.StateHasChanged();
     }
 
-    private Dictionary<Resources, int> PromptForResourcesInput()
-    {
-        Dictionary<Resources, int> numResources = new Dictionary<Resources, int>();
+    private void CheckPayDevelopers() {
+        // Pay developers round has just started. Call StartPayDevelopers and exit.
+        if (NumResources == null) {
+            StartPayDevelopers();
+            return;
+        }
 
-        //TODO: Get number for each resource through jQuery Dialog
+        if (PayDevelopersHandler.CheckResourcePayment(PlayerNumberToNumDevelopersLeft, NumResources)) {
+            ShowDialog = true;
+            UpdateMessage();
+        }
 
-        return numResources;
+        NumResources = null;
+        this.StateHasChanged();
     }
 
-    protected async Task ButtonClickedChanged() {
-        ButtonClicked = false;
-        message = GameLog.GetInstance().CurrentMessage;
+    public void UpdateMessage(string _message = null) {
+        if (_message is null)
+            _message = Log.CurrentMessage;
+
+        message = _message;
+    }
+
+    protected async Task ShowDialogChanged() {
+        ShowDialog = false;
+        UpdateMessage();
     }
 }
 <!-- #endregion -->

--- a/ScrumAge/BlazorUI/Pages/Index.razor
+++ b/ScrumAge/BlazorUI/Pages/Index.razor
@@ -60,10 +60,8 @@
 
         #if DEBUG
         playerNames = "seth;drew;";
-        #endif 
-        //var game = GameController.InitializeGameboard(playerNames);
-        //List<Player> players = InitializePlayers(playerNames);
-        //List<ILocation> locations = InitializeLocations();
+        #endif
+
         UriHelper.NavigateTo($"board/{playerNames}");
     }
 }

--- a/ScrumAge/BlazorUI/Shared/ResourceBoardComponent.razor
+++ b/ScrumAge/BlazorUI/Shared/ResourceBoardComponent.razor
@@ -9,22 +9,23 @@
 
     <h3 style="display: block">Bitcoin Investment Level: @_Player.Board.NumBitcoinInvestments</h3>  @*TEMPORARY, will be replaced by visual resource board*@
 
-    <h3 style="display: block">Player Score: @PlayerScore</h3>
+    <h3 style="display: block">Player Score: @_Player.Score</h3>
 
     <h3 style="display: block">Player Developers Left: @_Player.Board.NumDevelopersUnplaced</h3>  @*TEMPORARY, will be replaced by visual resource board*@
 
     <h3 style="display: block">Player Developers Owned: @_Player.Board.NumDevelopersOwned</h3>  @*TEMPORARY, will be replaced by visual resource board*@
 
+    <h3 style="display: block">Money: @_Player.Board.GetNumResource(Resources.Money)</h3>  @*TEMPORARY, will be replaced by visual resource board*@
     <h3 style="display: block">Coffee: @_Player.Board.GetNumResource(Resources.Coffee)</h3>  @*TEMPORARY, will be replaced by visual resource board*@
-    <h3 style="display: block">Power: @_Player.Board.GetNumResource(Resources.Power)</h3>  @*TEMPORARY, will be replaced by visual resource board*@
-    <h3 style="display: block">CPU Cores: @_Player.Board.GetNumResource(Resources.CPU_Cores)</h3>  @*TEMPORARY, will be replaced by visual resource board*@
     <h3 style="display: block">USB Sticks: @_Player.Board.GetNumResource(Resources.USB_Sticks)</h3>  @*TEMPORARY, will be replaced by visual resource board*@
+    <h3 style="display: block">CPU Cores: @_Player.Board.GetNumResource(Resources.CPU_Cores)</h3>  @*TEMPORARY, will be replaced by visual resource board*@
+    <h3 style="display: block">Power: @_Player.Board.GetNumResource(Resources.Power)</h3>  @*TEMPORARY, will be replaced by visual resource board*@
 </div>
 
 <style>
     div[ResourceCard] {
         padding:25px;
-        height: 300px;
+        height: 330px;
         width: 300px;
         border: none;
         display: inline-block;
@@ -38,8 +39,6 @@
 
 
 @code {
-    public int PlayerScore = 0;
-
     [Parameter]
     public Player _Player { get; set; }
 }

--- a/ScrumAge/BlazorUI/Shared/ResourceSelectorDialogBox.razor
+++ b/ScrumAge/BlazorUI/Shared/ResourceSelectorDialogBox.razor
@@ -1,0 +1,80 @@
+@namespace GameboardComponents
+@using BlazorUI.Pages
+@using GameLibrary.Models
+@using GameLibrary.Services;
+@using GameLibrary.Interfaces;
+
+<div resourceselectorarea>
+    <div resourceselectordialog>
+        <p>Please select a number for each resource.</p>
+        <p>
+            &#x2615 @numResources[Resources.Coffee] &#x1F4BE @numResources[Resources.USB_Sticks]
+            &#x1F4BB @numResources[Resources.CPU_Cores] &#x26A1 @numResources[Resources.Power]
+        </p>
+        <p>
+            <button class="btn btn-primary" @onclick="() => IncrementCount(Resources.Coffee)">&#x2615 +1</button>
+            <button class="btn btn-primary" @onclick="() => IncrementCount(Resources.USB_Sticks)">&#x1F4BE +1</button>
+            <button class="btn btn-primary" @onclick="() => IncrementCount(Resources.CPU_Cores)">&#x1F4BB +1</button>
+            <button class="btn btn-primary" @onclick="() => IncrementCount(Resources.Power)">&#x26A1 +1</button>
+        </p>
+        <p>
+            <button class="btn btn-primary" @onclick="() => DecrementCount(Resources.Coffee)">&#x2615 -1</button>
+            <button class="btn btn-primary" @onclick="() => DecrementCount(Resources.USB_Sticks)">&#x1F4BE -1</button>
+            <button class="btn btn-primary" @onclick="() => DecrementCount(Resources.CPU_Cores)">&#x1F4BB -1</button>
+            <button class="btn btn-primary" @onclick="() => DecrementCount(Resources.Power)">&#x26A1 -1</button>
+        </p>
+        <button class="btn btn-primary" @onclick="Confirm">Confirm</button>
+</div>
+
+    <ResourceBoardComponent _Player="player" />
+</div>
+
+<style>
+    div[resourceselectorarea] {
+        height: 100%;
+        width: 100%;
+        text-align: center;
+        vertical-align: middle;
+        background-color: transparent;
+        z-index: 5;
+    }
+
+    div[resourceselectordialog] {
+        height: 250px;
+        width: 400px;
+        width: 50%;
+        margin: 0 auto;
+        text-align: center;
+        background-color: darkseagreen;
+        z-index: 4;
+    }
+</style>
+
+@code {
+    [Parameter]
+    public EventCallback<bool> OnConfirm { get; set; }
+
+    private static Gameboard game = Gameboard.GetInstance();
+    private static GameLog log = GameLog.GetInstance();
+    private static Player player = game.CurrentPlayer;
+
+    private Dictionary<Resources, int> numResources = new Dictionary<Resources, int>() {
+        { Resources.Coffee, 0 }, { Resources.USB_Sticks, 0 },
+        { Resources.CPU_Cores, 0 }, { Resources.Power, 0 }
+    };
+
+    private void IncrementCount(Resources resource) {
+        if (numResources[resource] < player.Board.GetNumResource(resource))
+            numResources[resource]++;
+    }
+
+    private void DecrementCount(Resources resource) {
+        if (numResources[resource] > 0)
+            numResources[resource]--;
+    }
+
+    private async Task Confirm() {
+        Board.NumResources = numResources;
+        await OnConfirm.InvokeAsync(false);
+    }
+}

--- a/ScrumAge/GameLibrary/Models/GameRound.cs
+++ b/ScrumAge/GameLibrary/Models/GameRound.cs
@@ -9,6 +9,7 @@ namespace GameLibrary.Models
 	public enum GameRound {
 		PLACE_FIGURES,
 		TAKE_ACTIONS,
+		PAY_DEVELOPERS,
 		TALLY_SCORE
 	}
 }

--- a/ScrumAge/GameLibrary/Models/Locations/NerdLocation.cs
+++ b/ScrumAge/GameLibrary/Models/Locations/NerdLocation.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 namespace GameLibrary.Models.Locations
 {
     public class NerdLocation : AbstractLocation {
-        private const int MAX_OVERCLOCKS = 4;
+        private const int MAX_OVERCLOCKS = 3;
 
         public NerdLocation() {
             Name = "Nerd";

--- a/ScrumAge/GameLibrary/Models/Player.cs
+++ b/ScrumAge/GameLibrary/Models/Player.cs
@@ -11,6 +11,7 @@ namespace GameLibrary.Models {
     public class Player {
         public int Number { get; set; }
         public string Name { get; set; }
+        public int Score { get; set; }
         private Color figColor;
         public string FigColor 
         { 

--- a/ScrumAge/GameLibrary/Models/ResourceBoard.cs
+++ b/ScrumAge/GameLibrary/Models/ResourceBoard.cs
@@ -86,5 +86,18 @@ namespace GameLibrary.Models {
 
             LicenseTiles.Add(licenseTile);
         }
+
+        public int TotalNumResources() {
+            int total = 0;
+
+            Resources[] resources = { Resources.Coffee, Resources.USB_Sticks,
+                                      Resources.CPU_Cores, Resources.Power };
+            foreach (Resources resource in resources)
+            {
+                total += NumResources[resource];
+            }
+
+            return total;
+        }
     }
 }

--- a/ScrumAge/GameLibrary/Services/GameController.cs
+++ b/ScrumAge/GameLibrary/Services/GameController.cs
@@ -89,7 +89,7 @@ namespace GameLibrary.Services {
                 totalDevsUnplaced += p.Board.NumDevelopersUnplaced;
             }
             if (totalDevsOwned == totalDevsUnplaced) {
-                gameboard.Round = GameRound.TALLY_SCORE;
+                gameboard.Round = GameRound.PAY_DEVELOPERS;
             }
         }
         public static void TakeLocationAction(ILocation location, int overlockAddition) {

--- a/ScrumAge/GameLibrary/Services/GameController.cs
+++ b/ScrumAge/GameLibrary/Services/GameController.cs
@@ -123,7 +123,7 @@ namespace GameLibrary.Services {
                 totalDevsUnplaced += p.Board.NumDevelopersUnplaced;
             }
             if (totalDevsOwned == totalDevsUnplaced) {
-                gameboard.Round = GameRound.TALLY_SCORE;
+                gameboard.Round = GameRound.PAY_DEVELOPERS;
             }
         }
 
@@ -158,6 +158,19 @@ namespace GameLibrary.Services {
                 throw new ArgumentException("Need to place at least one developer.");
             }
             
+        }
+
+        public static void StartNewRound() {
+            Gameboard game = Gameboard.GetInstance();
+
+            game.CyclePlayers();
+            game.PlayersInRound = new Queue<Player>(game.Players);
+            game.Round = GameRound.PLACE_FIGURES;
+
+            //TODO: Slide ConCards to right
+            //TODO: Reveal new LicenseTiles
+            //TODO: Check for end of game
+            //TODO: Reset player tool tiles
         }
     }
 }

--- a/ScrumAge/GameLibrary/Services/PayDevelopersHandler.cs
+++ b/ScrumAge/GameLibrary/Services/PayDevelopersHandler.cs
@@ -7,24 +7,32 @@ using System.Threading.Tasks;
 using GameLibrary.Models;
 
 namespace GameLibrary.Services {
+
 	/*
-	 * Pays developers with money if possible, and deducts points from players who cannot pay developers.
-	 * Returns Dictionary<int, int> mapping player number to number of developers left to pay (can pay with resources).
+	 * Provides methods to pay developers at the end of each round.
 	 */
 	public class PayDevelopersHandler {
 		private const int SCORE_PENALTY = 10;
 
-		public static Dictionary<int, int> PayDevelopers() {
-			Gameboard board = Gameboard.GetInstance();
-			Dictionary<int, int> playerNumberToNumDevelopersLeft = new Dictionary<int, int>();
+		private static Gameboard game = Gameboard.GetInstance();
+		private static GameLog log = GameLog.GetInstance();
 
-			foreach (Player player in board.Players) {
+		/*
+		 * Pays developers with money if possible, and deducts points from players who cannot pay developers.
+		 * Returns Dictionary<int, int> mapping player number to number of developers left to pay (can pay with resources).
+		 */
+		public static Dictionary<int, int> AutoPayDevelopers() {
+			Dictionary<int, int> playerNumberToNumDevelopersLeft = new Dictionary<int, int>();
+			game.PlayersInRound = new Queue<Player>();
+
+			foreach (Player player in game.Players) {
 				int numDevelopersToPay = player.Board.NumDevelopersOwned;
 				int numMoney = player.Board.GetNumResource(Resources.Money);
 
 				if (numMoney >= numDevelopersToPay) {
 					// Can pay developers with money
 					player.Board.NumResources[Resources.Money] -= numDevelopersToPay;
+					log.AddMessage($"{player.Name} paid {numDevelopersToPay} developers with money.");
 				}
 				else {
 					// Cannot pay developers with money
@@ -34,15 +42,60 @@ namespace GameLibrary.Services {
 					if (player.Board.TotalNumResources() < numDevelopersToPay) {
 						// Cannot pay developers with resources
 						player.Score -= SCORE_PENALTY;
+						log.AddMessage($"{player.Name} could not pay developers, and lost {SCORE_PENALTY} points.");
 					}
 					else {
 						// May pay remaining developers with resources
 						playerNumberToNumDevelopersLeft[player.Number] = numDevelopersToPay;
+						game.PlayersInRound.Enqueue(player);
 					}
 				}
 			}
 
 			return playerNumberToNumDevelopersLeft;
+		}
+
+		/*
+		 * Pays the current player's developers using the numResources dictionary passed. If resource payment is
+		 * invalid, the current player is not cycled.
+		 * Returns true if any player will still need to pay with resources.
+		 */
+		public static bool CheckResourcePayment(
+			Dictionary<int, int> playerNumberToNumDevelopersLeft, Dictionary<Resources, int> numResources) {
+
+			Player player = game.CurrentPlayer;
+
+			// Check that player has enough resources to pay the selected amounts
+			int numResourcesPaid = 0;
+			foreach (Resources resource in numResources.Keys) {
+				if (numResources[resource] > player.Board.NumResources[resource]) {
+					log.AddMessage($"{player.Name} cannot pay with more resources than owned. Try again.");
+					return true;
+				}
+				numResourcesPaid += numResources[resource];
+			}
+
+			// Check that player has paid the correct number of resources
+			if (playerNumberToNumDevelopersLeft[player.Number] != numResourcesPaid)	{
+				log.AddMessage($"{player.Name} must pay developers with exactly"
+					+ $" {playerNumberToNumDevelopersLeft[player.Number]} resources. Try again.");
+				return true;
+			}
+
+			// Pay player's developers with resources selected
+			foreach (Resources resource in numResources.Keys)
+				player.Board.NumResources[resource] -= numResources[resource];
+			game.PlayersInRound.Dequeue();
+
+			// Start new round or move to next player
+			if (game.PlayersInRound.Count > 0) {
+				log.AddMessage($"{player.Name} must pay {playerNumberToNumDevelopersLeft[player.Number]}"
+					+ " developers with resources.");
+				return true;
+			}
+
+			GameController.StartNewRound();
+			return false;
 		}
 	}
 }

--- a/ScrumAge/GameLibrary/Services/PayDevelopersHandler.cs
+++ b/ScrumAge/GameLibrary/Services/PayDevelopersHandler.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using GameLibrary.Models;
+
+namespace GameLibrary.Services {
+	/*
+	 * Pays developers with money if possible, and deducts points from players who cannot pay developers.
+	 * Returns Dictionary<int, int> mapping player number to number of developers left to pay (can pay with resources).
+	 */
+	public class PayDevelopersHandler {
+		private const int SCORE_PENALTY = 10;
+
+		public static Dictionary<int, int> PayDevelopers() {
+			Gameboard board = Gameboard.GetInstance();
+			Dictionary<int, int> playerNumberToNumDevelopersLeft = new Dictionary<int, int>();
+
+			foreach (Player player in board.Players) {
+				int numDevelopersToPay = player.Board.NumDevelopersOwned;
+				int numMoney = player.Board.GetNumResource(Resources.Money);
+
+				if (numMoney >= numDevelopersToPay) {
+					// Can pay developers with money
+					player.Board.NumResources[Resources.Money] -= numDevelopersToPay;
+				}
+				else {
+					// Cannot pay developers with money
+					numDevelopersToPay -= player.Board.NumResources[Resources.Money];
+					player.Board.NumResources[Resources.Money] = 0;
+
+					if (player.Board.TotalNumResources() < numDevelopersToPay) {
+						// Cannot pay developers with resources
+						player.Score -= SCORE_PENALTY;
+					}
+					else {
+						// May pay remaining developers with resources
+						playerNumberToNumDevelopersLeft[player.Number] = numDevelopersToPay;
+					}
+				}
+			}
+
+			return playerNumberToNumDevelopersLeft;
+		}
+	}
+}


### PR DESCRIPTION
Paying developers with money and removing points if a player cannot pay is handled by PayDevelopersHandler.AutoPayDevelopers. Paying developers with resources requires user input, and is implemented in a sort-of loop involving re-rendering with this.StateHasChanged(). I may make a state/activity diagram to illustrate this, since it took a while to wrap my head around.

This also adds a ResourceSelectorDialogBox, which may be reused any time a player needs to pay with resources.

Board.razor is refactored some as well:
- ButtonClicked => ShowDialog, with same functionality.
- Addition of UpdateMessage() function.
- Addition of Log property
- Restructuring of top-level if statement