### PR TITLE
Implement cycle rounds functionality

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "razor.disableBlazorDebugPrompt": true
+}

--- a/ScrumAge/BlazorUI/Shared/TakeActionDialogBox.razor
+++ b/ScrumAge/BlazorUI/Shared/TakeActionDialogBox.razor
@@ -8,12 +8,17 @@
 
         @if (Location is OvertimeLocation || Location is ResourceLocation) {
             <p>At @Location.Name, Would you like to add Overclocks? (@TotalOverclock)</p>
-            @foreach (Overclock overclock in Gameboard.GetInstance().CurrentPlayer.Board.Overclocks) {
-                <input type="checkbox"
-                       @onchange="async eventArgs => { await OverclockSelect(overclock, eventArgs.Value); }"
-                       tabindex="" />
-                @overclock.Level<br />
-            }
+            <ul style="list-style:circle">
+                @foreach (Overclock overclock in Gameboard.GetInstance().CurrentPlayer.Board.Overclocks) {
+                <li style="display:inline">
+                    <label class="switch">
+                        &#9881 @overclock.Level
+                        <input type="checkbox" @onchange="eventArgs => {OverclockSelect(overclock, eventArgs.Value); }">
+                        <span class="slider"></span>
+                    </label>
+                </li>
+                }
+            </ul>
             <button @onclick="TakeLocationActionwithOverclock">Do it!!</button>
         }
         else {
@@ -21,6 +26,14 @@
             <button @onclick="TakeLocationAction">Do it!!</button>
         }
 
+    <label>
+        @foreach (var item in OverclockIndexes) {
+            @item
+        }
+        @Gameboard.GetInstance().CurrentPlayer.Name
+
+        @Gameboard.GetInstance().CurrentPlayer.Board.Overclocks.Count;
+    </label>
     </div>
 </div>
 
@@ -61,7 +74,7 @@
         TotalOverclock = 0;
     }
 
-    private async Task OverclockSelect(Overclock overclock, object value) {
+    private void OverclockSelect(Overclock overclock, object value) {
         int index = Gameboard.GetInstance().CurrentPlayer.Board.GetOverclockIndex(overclock);
         if ((bool)value == true) {
             TotalOverclock += overclock.Level;
@@ -71,15 +84,13 @@
             TotalOverclock -= overclock.Level;
             OverclockIndexes.Remove(index);
         }
+        OverclockIndexes.Sort();
+        OverclockIndexes.Reverse();
     }
 
     private async Task TakeLocationActionwithOverclock() {
         // call other method sig
-        GameController.TakeLocationAction(Location, TotalOverclock);
-
-        foreach (var index in OverclockIndexes) {
-            Gameboard.GetInstance().CurrentPlayer.Board.Overclocks.RemoveAt(index);
-        }
+        GameController.TakeLocationAction(Location, TotalOverclock, OverclockIndexes);
 
         await OnPlaceDeveloper.InvokeAsync(false);
     }

--- a/ScrumAge/GameLibrary/Models/Cards/LicenseTile.cs
+++ b/ScrumAge/GameLibrary/Models/Cards/LicenseTile.cs
@@ -85,7 +85,6 @@ namespace GameLibrary.Models {
                         break;
                     default:
                         throw new InvalidOperationException($"Cannot calculate score using invalid resource {resource}.");
-                        break;
                 }
             }
 

--- a/ScrumAge/GameLibrary/Models/Gameboard.cs
+++ b/ScrumAge/GameLibrary/Models/Gameboard.cs
@@ -171,21 +171,28 @@ namespace GameLibrary.Models {
                 new SandLowerConCard(SandConCardPerson.THERAPIST, 1));
             ((ConsultantCardLocation) GetLocation("Consultant Card3")).Card = card;
 
+            for (int i = 0; i < 15; i++)
+                ConCards.Enqueue(card);
+
             Dictionary<Resources, int> reqResources = new Dictionary<Resources, int>() {
                 { Resources.Coffee, 2 }, { Resources.Power, 1 } };
             LicenseTile tile = new LicenseTile(reqResources);
-            ((LicenseTileLocation) GetLocation("License Tile0")).Tiles.Enqueue(tile);
+            for (int i = 0; i < 5; i++)
+                ((LicenseTileLocation) GetLocation("License Tile0")).Tiles.Enqueue(tile);
 
             reqResources = new Dictionary<Resources, int>() {
                 { Resources.USB_Sticks, 2 }, { Resources.CPU_Cores, 1 } };
             tile = new LicenseTile(reqResources);
-            ((LicenseTileLocation) GetLocation("License Tile1")).Tiles.Enqueue(tile);
+            for (int i = 0; i < 5; i++)
+                ((LicenseTileLocation) GetLocation("License Tile1")).Tiles.Enqueue(tile);
 
             tile = new LicenseTile(4, 2);
-            ((LicenseTileLocation) GetLocation("License Tile2")).Tiles.Enqueue(tile);
+            for (int i = 0; i < 5; i++)
+                ((LicenseTileLocation) GetLocation("License Tile2")).Tiles.Enqueue(tile);
 
             tile = new LicenseTile();
-            ((LicenseTileLocation) GetLocation("License Tile3")).Tiles.Enqueue(tile);
+            for (int i = 0; i < 5; i++)
+                ((LicenseTileLocation) GetLocation("License Tile3")).Tiles.Enqueue(tile);
         }
     }
 }

--- a/ScrumAge/GameLibrary/Models/Gameboard.cs
+++ b/ScrumAge/GameLibrary/Models/Gameboard.cs
@@ -24,10 +24,6 @@ namespace GameLibrary.Models {
         /// The pile of Consultant Cards
         /// </summary>
         public Queue<ConsultantCard> ConCards { get; set; }
-        /// <summary>
-        /// The pile of License Tiles
-        /// </summary>
-        public Queue<LicenseTile> LicenseTiles { get; set; }
 
         /// <summary>Queue of Players in a Round; First player in queue is player whose turn it is.</summary>
         public Queue<Player> PlayersInRound { get; set; }
@@ -178,18 +174,18 @@ namespace GameLibrary.Models {
             Dictionary<Resources, int> reqResources = new Dictionary<Resources, int>() {
                 { Resources.Coffee, 2 }, { Resources.Power, 1 } };
             LicenseTile tile = new LicenseTile(reqResources);
-            ((LicenseTileLocation) GetLocation("License Tile0")).Tile = tile;
+            ((LicenseTileLocation) GetLocation("License Tile0")).Tiles.Enqueue(tile);
 
             reqResources = new Dictionary<Resources, int>() {
                 { Resources.USB_Sticks, 2 }, { Resources.CPU_Cores, 1 } };
             tile = new LicenseTile(reqResources);
-            ((LicenseTileLocation) GetLocation("License Tile1")).Tile = tile;
+            ((LicenseTileLocation) GetLocation("License Tile1")).Tiles.Enqueue(tile);
 
             tile = new LicenseTile(4, 2);
-            ((LicenseTileLocation) GetLocation("License Tile2")).Tile = tile;
+            ((LicenseTileLocation) GetLocation("License Tile2")).Tiles.Enqueue(tile);
 
             tile = new LicenseTile();
-            ((LicenseTileLocation) GetLocation("License Tile3")).Tile = tile;
+            ((LicenseTileLocation) GetLocation("License Tile3")).Tiles.Enqueue(tile);
         }
     }
 }

--- a/ScrumAge/GameLibrary/Models/Locations/LicenseTileLocation.cs
+++ b/ScrumAge/GameLibrary/Models/Locations/LicenseTileLocation.cs
@@ -9,17 +9,18 @@ namespace GameLibrary.Models.Locations
 {
 	public class LicenseTileLocation : AbstractLocation
 	{
-		public LicenseTile Tile { get; set; }
+		public LicenseTile Tile { get { return Tiles.Peek(); } }
+		public Queue<LicenseTile> Tiles { get; set; }
 
 		public LicenseTileLocation() {
 			Name = "License Tile";
 			numPlayerDevelopers = new List<int>() { 0, 0, 0, 0 };
 			NumDeveloperSpaces = 1;
+			Tiles = new Queue<LicenseTile>();
 		}
 
 		public override void TakeAction(ref Player player) {
-			player.Board.AddLicenseTile(Tile);
-			Tile = null;
+			player.Board.AddLicenseTile(Tiles.Dequeue());
 			ResetPlayerDevelopers(player);
 			GameController.CheckEndOfTakeActionsRound();
 		}

--- a/ScrumAge/GameLibrary/Services/GameController.cs
+++ b/ScrumAge/GameLibrary/Services/GameController.cs
@@ -211,7 +211,7 @@ namespace GameLibrary.Services {
         }
 
         public static void EndGame() {
-            //throw new NotImplementedException();
+            throw new NotImplementedException();
         }
     }
 }

--- a/ScrumAge/GameLibrary/Services/GameController.cs
+++ b/ScrumAge/GameLibrary/Services/GameController.cs
@@ -167,6 +167,11 @@ namespace GameLibrary.Services {
             Gameboard game = Gameboard.GetInstance();
             bool endConditionMet = false;
 
+			// Reset player overclocks
+			foreach (Player player in game.Players)
+				foreach (Overclock overclock in player.Board.Overclocks)
+                    overclock.Reset();
+
             // Shift consultant cards to right
             ConsultantCardLocation[] cardLocs = new ConsultantCardLocation[NUM_CARD_LOCS];
             for (int i = 0; i < NUM_CARD_LOCS; i++)
@@ -203,12 +208,10 @@ namespace GameLibrary.Services {
 
             if (endConditionMet)
                 EndGame();
-
-            //TODO: Reset player tool tiles
         }
 
         public static void EndGame() {
-            throw new NotImplementedException();
+            //throw new NotImplementedException();
         }
     }
 }

--- a/ScrumAge/GameLibrary/Services/GameController.cs
+++ b/ScrumAge/GameLibrary/Services/GameController.cs
@@ -13,6 +13,8 @@ namespace GameLibrary.Services {
     /// Initializes Game and acts as the interface between the backend and UI
     /// </summary>
     public static class GameController {
+        private const int NUM_CARD_LOCS = 4;
+
         /// <summary>
         /// Initializes Gameboard object's locations and players
         /// </summary>
@@ -158,15 +160,50 @@ namespace GameLibrary.Services {
 
         public static void StartNewRound() {
             Gameboard game = Gameboard.GetInstance();
+            bool endConditionMet = false;
 
+            // Shift consultant cards to right
+            ConsultantCardLocation[] cardLocs = new ConsultantCardLocation[NUM_CARD_LOCS];
+            for (int i = 0; i < NUM_CARD_LOCS; i++)
+                cardLocs[i] = (ConsultantCardLocation)game.GetLocation($"Consultant Card{i}");
+            
+            Queue<ConsultantCard> cards = new Queue<ConsultantCard>();
+            for (int i = NUM_CARD_LOCS - 1; i > 0; i--) {
+                if (cardLocs[i].Card is not null) {
+                    cards.Enqueue(cardLocs[i].Card);
+                    cardLocs[i].Card = null;
+                }
+            }
+
+            for (int i = NUM_CARD_LOCS - 1; i > 0; i--) {
+                if (cards.Count > 0)
+                    cardLocs[i].Card = cards.Dequeue();
+                else if (game.ConCards.Count == 0)
+                    endConditionMet = true;
+                else
+                    cardLocs[i].Card = game.ConCards.Dequeue();
+            }
+
+            // Check if any license tile locations are empty
+            for (int i = 0; i < NUM_CARD_LOCS; i++) {
+                var tileLoc = (LicenseTileLocation)game.GetLocation($"License Tile{i}");
+                if (tileLoc.Tiles.Count == 0)
+                    endConditionMet = true;
+            }
+
+            // Cycle players
             game.CyclePlayers();
             game.PlayersInRound = new Queue<Player>(game.Players);
             game.Round = GameRound.PLACE_FIGURES;
 
-            //TODO: Slide ConCards to right
-            //TODO: Reveal new LicenseTiles
-            //TODO: Check for end of game
+            if (endConditionMet)
+                EndGame();
+
             //TODO: Reset player tool tiles
+        }
+
+        public static void EndGame() {
+            throw new NotImplementedException();
         }
     }
 }

--- a/ScrumAge/GameLibrary/Services/GameController.cs
+++ b/ScrumAge/GameLibrary/Services/GameController.cs
@@ -81,7 +81,7 @@ namespace GameLibrary.Services {
             CheckEndOfTakeActionsRound();
         }
 
-        public static void TakeLocationAction(ILocation location, int overlockAddition) {
+        public static void TakeLocationAction(ILocation location, int overlockAddition, List<int> overclockIndexes) {
             Player player = Gameboard.GetInstance().CurrentPlayer;
             int numberofDevelopers = location.GetNumPlayerDevelopers(player);
 
@@ -93,6 +93,11 @@ namespace GameLibrary.Services {
                     throw new ArgumentException($"Player does not have any developers at {loc.Name}");
                 }
                 loc.TakeAction(ref player, overlockAddition);
+                // here 
+                foreach (var index in overclockIndexes) {
+                    player.Board.Overclocks.RemoveAt(index);
+                }
+                
             }
             catch (Exception e) {
                 Gameboard.GetInstance().AddToGameLog($"Sorry, {e.Message}");

--- a/ScrumAge/GameLibrary/Services/PayDevelopersHandler.cs
+++ b/ScrumAge/GameLibrary/Services/PayDevelopersHandler.cs
@@ -26,6 +26,8 @@ namespace GameLibrary.Services {
 			game.PlayersInRound = new Queue<Player>();
 
 			foreach (Player player in game.Players) {
+				player.Board.NumResources[Resources.Money] += player.Board.NumBitcoinInvestments;
+
 				int numDevelopersToPay = player.Board.NumDevelopersOwned;
 				int numMoney = player.Board.GetNumResource(Resources.Money);
 

--- a/ScrumAge/UnitTesting/NerdLocationTests.cs
+++ b/ScrumAge/UnitTesting/NerdLocationTests.cs
@@ -1,0 +1,84 @@
+﻿using GameLibrary.Interfaces;
+using GameLibrary.Models;
+using GameLibrary.Models.Locations;
+using GameLibrary.Services;
+using NUnit.Framework;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace UnitTesting {
+    [TestFixture]
+    public class NerdLocationTests {
+
+        Gameboard Game { get; set; }
+
+        [SetUp]
+        public void BaseSetUp() {
+            Game = GameController.InitializeGameboard("p1;");
+            GameController.PlaceDevelopers(1, Game.GetLocation("Nerd"));
+            GameController.PlaceDevelopers(4, Game.GetLocation("Overtime"));
+            GameController.TakeLocationAction(Game.GetLocation("Nerd"));
+            GameController.TakeLocationAction(Game.GetLocation("Overtime"));
+
+            GameController.PlaceDevelopers(1, Game.GetLocation("Nerd"));
+            GameController.PlaceDevelopers(4, Game.GetLocation("Overtime"));
+            GameController.TakeLocationAction(Game.GetLocation("Nerd"));
+            GameController.TakeLocationAction(Game.GetLocation("Overtime"));
+            
+            GameController.PlaceDevelopers(1, Game.GetLocation("Nerd"));
+            GameController.PlaceDevelopers(4, Game.GetLocation("Overtime"));
+            GameController.TakeLocationAction(Game.GetLocation("Nerd"));
+            GameController.TakeLocationAction(Game.GetLocation("Overtime"));
+        }
+
+        [Test]
+        public void CheckSetup() {
+            var overclocks = Game.CurrentPlayer.Board.Overclocks;
+            Assert.That(overclocks.Count == 3);
+        }
+
+        [Test]
+        public void CheckOverclockAdd() {
+            GameController.PlaceDevelopers(5, Game.GetLocation("Overtime"));
+
+            var overclocks = Game.CurrentPlayer.Board.Overclocks;
+            var overclockIndexes = new List<int>() { 0};
+            int sum = 0;
+            foreach (var item in overclockIndexes) {
+                sum += overclocks[item].Level;
+            }
+
+            GameController.TakeLocationAction(Game.GetLocation("Overtime"), sum, overclockIndexes);
+
+            Assert.That(Game.CurrentPlayer.Board.Overclocks.Count == 2);
+        }
+        [Test]
+        public void CheckMultipleOverclockAdd() {
+            GameController.PlaceDevelopers(1, Game.GetLocation("Nerd"));
+            GameController.PlaceDevelopers(4, Game.GetLocation("Overtime"));
+            GameController.TakeLocationAction(Game.GetLocation("Nerd"));
+            GameController.TakeLocationAction(Game.GetLocation("Overtime"));
+            GameController.PlaceDevelopers(1, Game.GetLocation("Nerd"));
+            GameController.PlaceDevelopers(4, Game.GetLocation("Overtime"));
+            GameController.TakeLocationAction(Game.GetLocation("Nerd"));
+            GameController.TakeLocationAction(Game.GetLocation("Overtime"));
+
+            GameController.PlaceDevelopers(5, Game.GetLocation("Overtime"));
+
+            var overclocks = Game.CurrentPlayer.Board.Overclocks;
+            var overclockIndexes = new List<int>() { 0 , 1};
+            int sum = 0;
+            foreach (var item in overclockIndexes) {
+                sum += overclocks[item].Level;
+            }
+
+            GameController.TakeLocationAction(Game.GetLocation("Overtime"), sum, overclockIndexes);
+
+            Assert.That(Game.CurrentPlayer.Board.Overclocks.Count == 1);
+        }
+    }
+}

--- a/ScrumAge/UnitTesting/OverclockTests.cs
+++ b/ScrumAge/UnitTesting/OverclockTests.cs
@@ -1,0 +1,98 @@
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using GameLibrary.Models;
+
+
+namespace UnitTesting 
+{
+    [TestFixture]
+    public class OverclockTests
+    {
+        [SetUp]
+        public void setUp()
+        {
+            //Arrange or Object Setup
+            var overclock = new GameLibrary.Models.Overclock();
+        }
+
+        [Test]
+        public void Upgrade_isAtMaxLevel_NoUpgrade()
+        {
+            var overclock = new GameLibrary.Models.Overclock();
+            //Assign level and max value
+            int startlevel = 4;
+            int maxValue = 4;
+
+            //Verify that level is not at Maximum level
+            if (startlevel == maxValue) {
+            //Act + Assert
+            Assert.Throws<InvalidOperationException>(() => overclock.Upgrade());
+            }
+        }
+        
+        [Test]
+        public void Upgrade_isNotAtMaxLevel_Upgraded()
+        {
+            //Arrange
+            var overclock = new GameLibrary.Models.Overclock();
+            //Assign level and max value
+            int startlevel = 1;
+            int maxValue = 4;
+
+            //Verify that level is not at Maximum level
+            if (startlevel < maxValue) {
+                //Act
+                startlevel++;
+            }
+            
+            //Assert
+            Assert.AreNotEqual(startlevel,maxValue);
+        }
+        
+        [Test]    
+        public void Overclock_hasBeenUsed_UseOperationException()
+        {
+            //initialize variable
+            bool HasBeenUsed = true;
+            //Arrange
+            var overclock = new GameLibrary.Models.Overclock();
+            //Act
+            overclock.Use();
+            if(HasBeenUsed) { 
+                //Assert
+                Assert.Throws<InvalidOperationException>(() => overclock.Use());
+            }
+        }
+        
+        [Test]  
+        public void Overclock_hasNotBeenUsed_Use()
+        {
+            //Arrange
+            var overclock = new Overclock();
+            //Act
+            overclock.Use();
+            //Assert
+            Assert.IsFalse(overclock.HasBeenUsed);
+        }
+        
+        [Test]
+        public void Overclock_Reset()
+        {      
+            //initialize variable
+            bool HasBeenUsed = false;
+            //Arrange
+            var overclock = new GameLibrary.Models.Overclock();
+            //Act
+            overclock.Reset();
+            
+            if(HasBeenUsed) { 
+                //Assert
+                Assert.IsFalse(overclock.HasBeenUsed);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Shifting ConCards at end of round, making license tile locations store a queue of tiles, and checking end conditions for both. Also add money equal to a player's bitcoin investment level before paying developers.