### PR TITLE
Maxing a stat Soft Lock Issue

### DIFF
--- a/ScrumAge/GameLibrary/Services/GameController.cs
+++ b/ScrumAge/GameLibrary/Services/GameController.cs
@@ -73,7 +73,7 @@ namespace GameLibrary.Services {
             }
             catch (Exception e) {
                 Gameboard.GetInstance().AddToGameLog($"Sorry, {e.Message}");
-                return;
+                location.ResetPlayerDevelopers(player);
             }
 
             CheckEndOfTakeActionsRound();
@@ -99,7 +99,7 @@ namespace GameLibrary.Services {
             }
             catch (Exception e) {
                 Gameboard.GetInstance().AddToGameLog($"Sorry, {e.Message}");
-                return;
+                location.ResetPlayerDevelopers(player);
             }
 
             CheckEndOfTakeActionsRound();


### PR DESCRIPTION
As a player, if I have max level on a stat, I do not want to get into a soft lock when I am dumb and try to take action on something I am maxed out in.

Fix: return in the catch since we have error checking for this
changed lines 76 and 102 in Services.GameController.cs from 'return;' to 'location.ResetPlayerDevelopers(player);'